### PR TITLE
Add GeNomad-based plasmid scoring of gene contexts

### DIFF
--- a/ginger/constants.py
+++ b/ginger/constants.py
@@ -12,4 +12,6 @@ CONTEXT_LEVEL_OUTPUT_TEMPLATE = '{out_dir}/context_level_matches.csv'
 SPECIES_LEVEL_OUTPUT_TEMPLATE = '{out_dir}/species_level_matches.csv'
 SUBSPECIES_LEVEL_OUTPUT_TEMPLATE = '{out_dir}/subspecies_level_matches.csv'
 GENES_DETECTED_IN_GRAPH_WITH_NO_SPECIES_MATCH_OUTPUT_TEMPLATE = '{out_dir}/genes_detected_in_graph_with_no_species_match.csv'
+PLASMID_DETECTION_INPUT_FASTA_TEMPLATE = '{temp_folder}/plasmid_detection_input.fasta'
+GENOMAD_OUTPUT_DIR_TEMPLATE = '{out_dir}/genomad_output'
 

--- a/ginger/ginger_runner.py
+++ b/ginger/ginger_runner.py
@@ -15,6 +15,7 @@ from ginger import extract_contexts_candidates as ecc
 from ginger import sequence_alignment_utils as sau
 from ginger import verify_context_candidates as vcc
 from ginger import pipeline_utils as pu
+from ginger import plasmid_detection_utils as pdu
 from ginger import constants as c
 
 
@@ -39,7 +40,8 @@ def cleanup_intermediate_files(out_dir, keep_options):
         'alignment': ['*.paf', '*.m8', 'mmseqs_tmp', 'nodes_to_contigs_w_gaps.paf'],
         'sequences': ['all_in_paths.fasta', 'all_out_paths.fasta'],
         'kraken': ['kraken_*.tsv', 'bracken_*.tsv'],
-        'reference': ['merged_filtered_ref_db.*', 'references_used.csv']
+        'reference': ['merged_filtered_ref_db.*', 'references_used.csv'],
+        'plasmid': ['plasmid_detection_input.fasta', 'genomad_output'],
     }
     
     # Remove categories not in keep_options
@@ -114,20 +116,26 @@ def cleanup_intermediate_files(out_dir, keep_options):
 @click.option('--paths-pident-filtering-th', type=float, default=0.9,
               help='The minimal % of matched base pairs required for matching a context candidate to a reference sequence')
 @click.option('--keep-intermediate', multiple=True,
-              type=click.Choice(['all', 'final', 'assembly', 'alignment', 'sequences', 'kraken', 'reference'],
+              type=click.Choice(['all', 'final', 'assembly', 'alignment', 'sequences', 'kraken', 'reference', 'plasmid'],
                                case_sensitive=False),
               default=['all'],
-              help='Specify which intermediate files to keep. Options: all (default, keep everything), final (only result CSVs), assembly (SPAdes output), alignment (PAF/M8 files), sequences (FASTA files), kraken (Kraken2/Bracken output), reference (reference database files). Can specify multiple by repeating the flag: --keep-intermediate final --keep-intermediate assembly')
+              help='Specify which intermediate files to keep. Options: all (default, keep everything), final (only result CSVs), assembly (SPAdes output), alignment (PAF/M8 files), sequences (FASTA files), kraken (Kraken2/Bracken output), reference (reference database files), plasmid (GeNomad input fasta and output directory). Can specify multiple by repeating the flag: --keep-intermediate final --keep-intermediate assembly')
 @click.option('--skip-assembly', is_flag=True, default=False,
               help='A flag that indicates whether or not to skip the assembly step. If the flag is set to True, the argument --assembly--dir must be supplied and direct to the results of a SPAdes run')
 @click.option('--return-all-gene-matches', is_flag=True, default=False,
               help='By default, GInGeR applies non-max-suppression (NMS) to the alignment of genes of interest to the assembly graph, keeping only top scoring matches and removing redundant overlapping matches. If this flag is set to True, all gene matches will be returned without applying NMS.')
 @click.option('--nms-iou-threshold', type=float, default=0.8,
               help='The IoU (Intersection over Union) threshold used for non-max-suppression when filtering overlapping gene matches. Gene matches with IoU > this threshold are considered overlapping. Only used when --return-all-gene-matches is False. Default: 0.8')
+@click.option('--add-plasmid-score/--no-add-plasmid-score', default=True,
+              help='Run GeNomad on the genomic contexts found for each gene (and on the contigs of genes with no species-level match) and add plasmid_score columns to the output CSVs. Requires --genomad-db to point to a valid GeNomad database. Default: True')
+@click.option('--genomad-db', type=click.Path(),
+              default=os.path.join(os.path.dirname(__file__), '..', 'genomad_db'),
+              help="The path to GeNomad's database directory (create one with `genomad download-database <path>`). Only used when --add-plasmid-score is set.")
 def run_ginger_e2e(long_reads, short_reads_1, short_reads_2, out_dir, assembly_dir, threads, kraken_output_path,
                    kraken_db, species_coverage_threshold, reference_genomes_metadata, downloaded_references_dir, sample_specific_references, genes_path, depth_limit,
                    max_gap_ratio, max_context_len, min_context_len, gene_pident_filtering_th,
-                   paths_pident_filtering_th, keep_intermediate, skip_assembly, max_species_representatives, return_all_gene_matches, nms_iou_threshold):
+                   paths_pident_filtering_th, keep_intermediate, skip_assembly, max_species_representatives, return_all_gene_matches, nms_iou_threshold,
+                   add_plasmid_score, genomad_db):
     """GInGeR - A tool for analyzing the genomic contexts of genes in metagenomic samples.
 
     \b
@@ -146,13 +154,15 @@ t
     return ginger_e2e_func(long_reads, short_reads_1, short_reads_2, out_dir, assembly_dir, threads, kraken_output_path,
                            kraken_db, species_coverage_threshold, reference_genomes_metadata, downloaded_references_dir, sample_specific_references, genes_path,
                            depth_limit, max_gap_ratio, min_context_len, max_context_len, gene_pident_filtering_th,
-                           paths_pident_filtering_th, keep_intermediate, skip_assembly, max_species_representatives, return_all_gene_matches, nms_iou_threshold)
+                           paths_pident_filtering_th, keep_intermediate, skip_assembly, max_species_representatives, return_all_gene_matches, nms_iou_threshold,
+                           add_plasmid_score, genomad_db)
 
 
 def ginger_e2e_func(long_reads, short_reads_1, short_reads_2, out_dir, assembly_dir, threads, kraken_output_path,
                     kraken_db, species_coverage_threshold, reference_genomes_metadata, downloaded_references_dir, sample_specific_references, genes_path, depth_limit,
                     max_gap_ratio, min_context_len, max_context_len, gene_pident_filtering_th,
-                    paths_pident_filtering_th, keep_intermediate, skip_assembly, max_species_representatives, return_all_gene_matches, nms_iou_threshold):
+                    paths_pident_filtering_th, keep_intermediate, skip_assembly, max_species_representatives, return_all_gene_matches, nms_iou_threshold,
+                    add_plasmid_score=True, genomad_db=None):
     # Log the command that was run
     log.info(f"Running GInGeR with command: {' '.join(sys.argv)}")
     
@@ -220,12 +230,30 @@ def ginger_e2e_func(long_reads, short_reads_1, short_reads_2, out_dir, assembly_
                                                                     out_contexts_to_ref_genomes,
                                                                     gene_lengths, paths_pident_filtering_th, 0,
                                                                     max_gap_ratio, reference_genomes_metadata)
+
+    # run GeNomad on the gene contexts and on the contigs of genes with no species-level match
+    context_plasmid_scores, contig_plasmid_scores = None, None
+    if add_plasmid_score:
+        genes_with_context_matches = {gene for gene, _ in context_level_results.keys()} if context_level_results else set()
+        plasmid_input_fasta = c.PLASMID_DETECTION_INPUT_FASTA_TEMPLATE.format(temp_folder=out_dir)
+        plasmid_fasta_path = pdu.write_plasmid_detection_input_fasta(
+            context_level_results, genes_with_location_in_graph, genes_with_context_matches,
+            in_paths_fasta, out_paths_fasta, c.CONTIGS_PATH_TEMPLATE.format(assembly_dir=assembly_dir),
+            plasmid_input_fasta)
+        if plasmid_fasta_path:
+            genomad_out_dir = c.GENOMAD_OUTPUT_DIR_TEMPLATE.format(out_dir=out_dir)
+            plasmid_summary_path = pdu.run_genomad(plasmid_fasta_path, genomad_out_dir, genomad_db, threads)
+            context_plasmid_scores, contig_plasmid_scores = pdu.read_plasmid_scores(plasmid_summary_path)
+
     if not context_level_results:
-        pu.write_genes_detected_in_graph_with_no_species_match(
+        wrote_no_species_match_csv = pu.write_genes_detected_in_graph_with_no_species_match(
             genes_with_location_in_graph,
             matched_genes=set(),
             csv_path=genes_detected_no_species_match_output_path,
         )
+        if wrote_no_species_match_csv and contig_plasmid_scores is not None:
+            pdu.add_plasmid_scores_to_genes_no_species_match_csv(genes_detected_no_species_match_output_path,
+                                                                 contig_plasmid_scores)
         log.info(
             'No matching pairs of incoming and outgoing contexts found in reference sequences. GInGeR run stopped - no results generated')
         return
@@ -233,6 +261,9 @@ def ginger_e2e_func(long_reads, short_reads_1, short_reads_2, out_dir, assembly_
     species_level_output_path = c.SPECIES_LEVEL_OUTPUT_TEMPLATE.format(out_dir=out_dir)
     subspecies_level_output_path = c.SUBSPECIES_LEVEL_OUTPUT_TEMPLATE.format(out_dir=out_dir)
     pu.write_context_level_output_to_csv(context_level_results, context_level_output_path, reference_genomes_metadata)
+    if context_plasmid_scores is not None:
+        pdu.add_plasmid_scores_to_context_level_csv(context_level_output_path, context_plasmid_scores)
+
     species_level_df = pu.aggregate_context_level_output_to_species_level_output_and_write_csv(context_level_output_path,
                                                                                                reference_genomes_metadata,
                                                                                                species_level_output_path,
@@ -250,11 +281,14 @@ def ginger_e2e_func(long_reads, short_reads_1, short_reads_2, out_dir, assembly_
         # species_level_df has a MultiIndex (gene, species)
         matched_genes = set(species_level_df.index.get_level_values(0))
 
-    pu.write_genes_detected_in_graph_with_no_species_match(
+    wrote_no_species_match_csv = pu.write_genes_detected_in_graph_with_no_species_match(
         genes_with_location_in_graph,
         matched_genes=matched_genes,
         csv_path=genes_detected_no_species_match_output_path,
     )
+    if wrote_no_species_match_csv and contig_plasmid_scores is not None:
+        pdu.add_plasmid_scores_to_genes_no_species_match_csv(genes_detected_no_species_match_output_path,
+                                                             contig_plasmid_scores)
     # Clean up intermediate files if requested
     cleanup_intermediate_files(out_dir, keep_intermediate)
     

--- a/ginger/pipeline_utils.py
+++ b/ginger/pipeline_utils.py
@@ -217,6 +217,26 @@ def aggregate_context_level_output_to_species_level_output_and_write_csv(context
     agg_output = agg_output.merge(genomes_per_species, left_on=species_col, right_index=True, how='left')
     agg_output['references_ratio'] = agg_output['genome_nunique'] / agg_output[f'{species_col}_instances']
     species_level_output = agg_output[['references_ratio', 'score_max', f'{species_col}_instances']]
+
+    if 'plasmid_score' in context_level_df.columns:
+        group_cols = ['gene', species_col]
+        context_cols = ['in_context', 'out_context']
+
+        # average plasmid score across the gene's unique contexts (don't over-weight contexts
+        # that were matched to many reference genomes of the same species)
+        unique_contexts = context_level_df.drop_duplicates(group_cols + context_cols)
+        plasmid_score_mean = unique_contexts.groupby(group_cols)['plasmid_score'].mean().rename('plasmid_score_mean')
+
+        # plasmid score of the context(s) matched to the most reference genomes, averaging ties
+        context_counts = context_level_df.groupby(group_cols + context_cols).size().reset_index(name='n_genomes')
+        context_counts = context_counts.merge(unique_contexts[group_cols + context_cols + ['plasmid_score']],
+                                               on=group_cols + context_cols)
+        max_counts = context_counts.groupby(group_cols)['n_genomes'].transform('max')
+        plasmid_score_most_common_context = context_counts[context_counts['n_genomes'] == max_counts].groupby(
+            group_cols)['plasmid_score'].mean().rename('plasmid_score_most_common_context')
+
+        species_level_output = species_level_output.join(plasmid_score_mean).join(plasmid_score_most_common_context)
+
     if species_level_output_path is not None:
         species_level_output.to_csv(species_level_output_path)
     return species_level_output

--- a/ginger/plasmid_detection_utils.py
+++ b/ginger/plasmid_detection_utils.py
@@ -1,0 +1,133 @@
+import os
+import logging
+from subprocess import run
+import pandas as pd
+from Bio import SeqIO
+from Bio.Seq import Seq
+
+from ginger import pipeline_utils as pu
+
+log = logging.getLogger(__name__)
+
+GENOMAD_COMMAND = 'genomad end-to-end --threads {threads} --cleanup {fasta_path} {output_dir} {genomad_db} --min-score 0'
+
+
+def _fasta_to_dict(fasta_path: str) -> dict:
+    with open(fasta_path) as f:
+        return {rec.id: str(rec.seq) for rec in SeqIO.parse(f, 'fasta')}
+
+
+def _get_gene_sequence(contig_seq: str, gene_match) -> str:
+    seq = contig_seq[gene_match.start - 1:gene_match.end]
+    if gene_match.strand == '-':
+        seq = str(Seq(seq).reverse_complement())
+    return seq
+
+
+def write_plasmid_detection_input_fasta(context_level_results, genes_with_location_in_graph, matched_genes,
+                                        in_paths_fasta, out_paths_fasta, contigs_fasta, output_fasta_path):
+    """Writes a FASTA file to be used as GeNomad's input, containing:
+    - for every unique (gene, in_context, out_context) trio in context_level_results, the
+      concatenation of the in-path, gene and out-path sequences, with header "{gene}|{in_context}|{out_context}"
+    - for every gene in genes_with_location_in_graph that is not in matched_genes, the full
+      sequence of the contig it was found on, with header "{contig}"
+
+    Returns the path to the written fasta, or None if there was nothing to write.
+    """
+    best_match_by_gene = {}
+    for gene_match in genes_with_location_in_graph:
+        current_best = best_match_by_gene.get(gene_match.gene)
+        if current_best is None or gene_match.score > current_best.score:
+            best_match_by_gene[gene_match.gene] = gene_match
+
+    contig_seq_by_id = _fasta_to_dict(contigs_fasta)
+
+    wrote_any = False
+    with open(output_fasta_path, 'w') as f:
+        if context_level_results:
+            in_seq_by_id = _fasta_to_dict(in_paths_fasta)
+            out_seq_by_id = _fasta_to_dict(out_paths_fasta)
+
+            trios = set()
+            for matches_list in context_level_results.values():
+                for match in matches_list:
+                    trios.add((match.gene, match.in_path.query_name, match.out_path.query_name))
+
+            for gene, in_context, out_context in trios:
+                gene_match = best_match_by_gene.get(gene)
+                if gene_match is None:
+                    continue
+                gene_seq = _get_gene_sequence(contig_seq_by_id[gene_match.contig], gene_match)
+                full_seq = in_seq_by_id[in_context] + gene_seq + out_seq_by_id[out_context]
+                f.write(f'>{gene}|{in_context}|{out_context}\n{full_seq}\n')
+                wrote_any = True
+
+        written_contigs = set()
+        for gene_match in genes_with_location_in_graph:
+            if gene_match.gene not in matched_genes and gene_match.contig not in written_contigs:
+                f.write(f'>{gene_match.contig}\n{contig_seq_by_id[gene_match.contig]}\n')
+                written_contigs.add(gene_match.contig)
+                wrote_any = True
+
+    if not wrote_any:
+        os.remove(output_fasta_path)
+        return None
+    return output_fasta_path
+
+
+@pu.step_timing
+def run_genomad(fasta_path, output_dir, genomad_db, threads):
+    if not os.path.exists(genomad_db):
+        raise Exception(f'GeNomad database does not exist in {genomad_db}')
+
+    pu.check_and_make_dir_no_file_name(output_dir)
+    command = GENOMAD_COMMAND.format(threads=threads, fasta_path=fasta_path, output_dir=output_dir,
+                                     genomad_db=genomad_db)
+    log.info(f'Running GeNomad - {command}')
+    command_output = run(command, shell=True, capture_output=True)
+    if command_output.returncode:
+        log.error(f'GeNomad failed: {command_output.stderr}')
+        raise Exception('GeNomad failed - GInGeR aborted')
+    log.info('GeNomad completed successfully')
+
+    fasta_stem = os.path.splitext(os.path.basename(fasta_path))[0]
+    return os.path.join(output_dir, f'{fasta_stem}_summary', f'{fasta_stem}_plasmid_summary.tsv')
+
+
+def read_plasmid_scores(plasmid_summary_path):
+    """Reads GeNomad's plasmid_summary.tsv and splits the results into context-level and
+    contig-level plasmid scores based on whether seq_name is a "{gene}|{in_context}|{out_context}"
+    composite header or a plain contig name.
+
+    Returns a tuple (context_plasmid_scores, contig_plasmid_scores):
+    - context_plasmid_scores has columns [gene, in_context, out_context, plasmid_score]
+    - contig_plasmid_scores has columns [contig, plasmid_score]
+    """
+    summary_df = pd.read_csv(plasmid_summary_path, sep='\t')[['seq_name', 'plasmid_score']]
+    is_context = summary_df['seq_name'].str.contains('|', regex=False)
+
+    context_plasmid_scores = summary_df[is_context].copy()
+    context_split = context_plasmid_scores['seq_name'].str.split('|', expand=True)
+    context_plasmid_scores['gene'] = context_split[0]
+    context_plasmid_scores['in_context'] = context_split[1]
+    context_plasmid_scores['out_context'] = context_split[2]
+    context_plasmid_scores = context_plasmid_scores[['gene', 'in_context', 'out_context', 'plasmid_score']]
+
+    contig_plasmid_scores = summary_df[~is_context].rename(columns={'seq_name': 'contig'})[['contig', 'plasmid_score']]
+
+    return context_plasmid_scores, contig_plasmid_scores
+
+
+def add_plasmid_scores_to_context_level_csv(context_level_csv_path, context_plasmid_scores):
+    context_level_df = pd.read_csv(context_level_csv_path)
+    context_level_df = context_level_df.merge(context_plasmid_scores, on=['gene', 'in_context', 'out_context'],
+                                              how='left')
+    context_level_df['plasmid_score'] = context_level_df['plasmid_score'].fillna(0)
+    context_level_df.to_csv(context_level_csv_path, index=False)
+
+
+def add_plasmid_scores_to_genes_no_species_match_csv(csv_path, contig_plasmid_scores):
+    genes_df = pd.read_csv(csv_path)
+    genes_df = genes_df.merge(contig_plasmid_scores, on='contig', how='left')
+    genes_df['plasmid_score'] = genes_df['plasmid_score'].fillna(0)
+    genes_df.to_csv(csv_path, index=False)

--- a/tests/test_files/context_level_matches_with_plasmid_score.csv
+++ b/tests/test_files/context_level_matches_with_plasmid_score.csv
@@ -1,0 +1,4 @@
+gene,Genome,species,score,in_context,out_context,plasmid_score
+test_gene,MGYG000260594,Escherichia coli_D,0.95,ctx1_in,ctx1_out,0.9
+test_gene,MGYG000260595,Escherichia coli_D,0.90,ctx1_in,ctx1_out,0.9
+test_gene,MGYG000260596,Escherichia coli_D,0.85,ctx2_in,ctx2_out,0.3

--- a/tests/test_ginger_runner.py
+++ b/tests/test_ginger_runner.py
@@ -51,7 +51,8 @@ class GingerRunnerTest(unittest.TestCase):
     def test_ginger_e2e_func(self):
         ginger_e2e_func(None, self.short_reads_1, self.short_reads_2, self.out_dir, None, self.threads, None,
                         None, self.coverage_th, self.metadata_path, 'references_dir', self.merged_filtered_fasta,
-                        self.genes_path, 12, 1.5, 0, 2500, 0.9, 0.9, ['all'], False, self.max_species_representatives, False, 0.8)
+                        self.genes_path, 12, 1.5, 0, 2500, 0.9, 0.9, ['all'], False, self.max_species_representatives, False, 0.8,
+                        add_plasmid_score=False)
 
         self.assertTrue(os.path.exists(f'{self.out_dir}/context_level_matches.csv'))
         self.assertTrue(os.path.exists(f'{self.out_dir}/species_level_matches.csv'))
@@ -95,7 +96,7 @@ class GingerRunnerTest(unittest.TestCase):
         runner = CliRunner()
 
         result = runner.invoke(run_ginger_e2e,
-                               f'{self.short_reads_1} {self.short_reads_2} {self.genes_path} {self.out_dir} --sample-specific-references {self.merged_filtered_fasta} --species-coverage-threshold {self.coverage_th} --reference-genomes-metadata {self.metadata_path} --max-species-representatives 1'.split(
+                               f'{self.short_reads_1} {self.short_reads_2} {self.genes_path} {self.out_dir} --sample-specific-references {self.merged_filtered_fasta} --species-coverage-threshold {self.coverage_th} --reference-genomes-metadata {self.metadata_path} --max-species-representatives 1 --no-add-plasmid-score'.split(
                                    ' '))
         self.assertEqual(result.exit_code, 0, str(result.exception))
         self.assertTrue(os.path.exists(f'{self.out_dir}/context_level_matches.csv'))

--- a/tests/test_pipeline_utils.py
+++ b/tests/test_pipeline_utils.py
@@ -21,10 +21,12 @@ class PipelineUtilsTest(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.context_level_output_path = f'{TEST_FILES}/context_level_matches.csv'
         cls.context_level_output_path_with_dups = f'{TEST_FILES}/context_level_matches_with_dups.csv'  # dups means that the same gene is matched to the same genome twice
+        cls.context_level_output_path_with_plasmid_score = f'{TEST_FILES}/context_level_matches_with_plasmid_score.csv'
         cls.metadata_path = 'ginger/UHGG-metadata.tsv' # use this for running tests on github CI
         # cls.metadata_path = '../ginger/UHGG-metadata.tsv' # use this for running the test locally
         cls.species_level_output_path = 'test_species_level_matches.csv'
         cls.species_level_output_path_with_dups = f'test_species_level_matches_with_dups.csv'  # dups means that the same gene is matched to the same genome twice
+        cls.species_level_output_path_with_plasmid_score = 'test_species_level_matches_with_plasmid_score.csv'
         # GT files
         cls.species_level_output_path_gt = f'{TEST_FILES}/species_level_matches.csv'
         cls.species_level_output_path_with_dups_gt = f'{TEST_FILES}/species_level_matches_with_dups.csv'
@@ -33,6 +35,8 @@ class PipelineUtilsTest(unittest.TestCase):
     def tearDownClass(cls) -> None:
         if os.path.exists(cls.species_level_output_path):
             os.remove(cls.species_level_output_path)
+        if os.path.exists(cls.species_level_output_path_with_plasmid_score):
+            os.remove(cls.species_level_output_path_with_plasmid_score)
 
     def test_aggregate_context_level_output_to_species_level_output_and_write_csv(self):
         pu.aggregate_context_level_output_to_species_level_output_and_write_csv(self.context_level_output_path,
@@ -55,6 +59,22 @@ class PipelineUtilsTest(unittest.TestCase):
             out_lines = out_f.readlines()
             gt_lines = gt_f.readlines()
         self.assertListEqual(out_lines, gt_lines)
+
+    def test_aggregate_context_level_output_to_species_level_output_and_write_csv_with_plasmid_score(self):
+        species_level_output = pu.aggregate_context_level_output_to_species_level_output_and_write_csv(
+            self.context_level_output_path_with_plasmid_score,
+            self.metadata_path,
+            self.species_level_output_path_with_plasmid_score, 1)
+
+        self.assertTrue(os.path.exists(self.species_level_output_path_with_plasmid_score))
+        self.assertIn('plasmid_score_mean', species_level_output.columns)
+        self.assertIn('plasmid_score_most_common_context', species_level_output.columns)
+
+        row = species_level_output.loc[('test_gene', 'Escherichia coli_D')]
+        # plasmid_score_mean averages over the gene's two unique contexts (0.9 and 0.3)
+        self.assertAlmostEqual(row['plasmid_score_mean'], 0.6)
+        # plasmid_score_most_common_context is the score of the context matched to 2 genomes (0.9), not 1 (0.3)
+        self.assertAlmostEqual(row['plasmid_score_most_common_context'], 0.9)
 
     def test_parse_paths_file(self):
         paths_file = f'{TEST_FILES}/SPAdes/contigs.paths'

--- a/tests/test_plasmid_detection_utils.py
+++ b/tests/test_plasmid_detection_utils.py
@@ -1,0 +1,236 @@
+import os
+import tempfile
+import shutil
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+from ginger import plasmid_detection_utils as pdu
+
+
+class FakeGeneMatch:
+    def __init__(self, gene, contig, score, start, end, strand):
+        self.gene = gene
+        self.contig = contig
+        self.score = score
+        self.start = start
+        self.end = end
+        self.strand = strand
+
+
+class FakePathMatch:
+    def __init__(self, query_name):
+        self.query_name = query_name
+
+
+class FakeInOutMatch:
+    def __init__(self, gene, in_context, out_context):
+        self.gene = gene
+        self.in_path = FakePathMatch(in_context)
+        self.out_path = FakePathMatch(out_context)
+
+
+class WritePlasmidDetectionInputFastaTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
+
+    def _write_fasta(self, name, records):
+        path = os.path.join(self.tmp_dir, name)
+        with open(path, 'w') as f:
+            for header, seq in records.items():
+                f.write(f'>{header}\n{seq}\n')
+        return path
+
+    def test_writes_context_trios_and_unmatched_contigs(self):
+        in_paths_fasta = self._write_fasta('in.fasta', {'in_ctx1': 'IIIIIIII'})
+        out_paths_fasta = self._write_fasta('out.fasta', {'out_ctx1': 'OOOOOOOO'})
+        contigs_fasta = self._write_fasta('contigs.fasta', {
+            'contig1': 'ACGTACGTAC',
+            'contig2': 'GGGGCCCCAA',
+        })
+
+        genes_with_location_in_graph = [
+            FakeGeneMatch('geneA', 'contig1', 1.0, 3, 6, '+'),
+            FakeGeneMatch('geneB', 'contig2', 1.0, 1, 4, '-'),
+        ]
+        context_level_results = {
+            ('geneA', 'ref_genome1'): [FakeInOutMatch('geneA', 'in_ctx1', 'out_ctx1')],
+        }
+        matched_genes = {'geneA'}
+
+        output_fasta_path = os.path.join(self.tmp_dir, 'plasmid_input.fasta')
+        result_path = pdu.write_plasmid_detection_input_fasta(
+            context_level_results, genes_with_location_in_graph, matched_genes,
+            in_paths_fasta, out_paths_fasta, contigs_fasta, output_fasta_path)
+
+        self.assertEqual(result_path, output_fasta_path)
+        records = pdu._fasta_to_dict(output_fasta_path)
+        # geneA's context: in-path + gene sequence (contig1[2:6] = "GTAC") + out-path
+        self.assertEqual(records['geneA|in_ctx1|out_ctx1'], 'IIIIIIIIGTACOOOOOOOO')
+        # geneB has no context match, so its full (unmatched) contig is included as-is
+        self.assertEqual(records['contig2'], 'GGGGCCCCAA')
+        self.assertNotIn('contig1', records)
+
+    def test_returns_none_and_removes_file_when_nothing_to_write(self):
+        in_paths_fasta = self._write_fasta('in.fasta', {})
+        out_paths_fasta = self._write_fasta('out.fasta', {})
+        contigs_fasta = self._write_fasta('contigs.fasta', {'contig1': 'ACGTACGTAC'})
+
+        genes_with_location_in_graph = [
+            FakeGeneMatch('geneA', 'contig1', 1.0, 3, 6, '+'),
+        ]
+        matched_genes = {'geneA'}  # geneA is matched, so its contig is not included
+
+        output_fasta_path = os.path.join(self.tmp_dir, 'plasmid_input.fasta')
+        result_path = pdu.write_plasmid_detection_input_fasta(
+            {}, genes_with_location_in_graph, matched_genes,
+            in_paths_fasta, out_paths_fasta, contigs_fasta, output_fasta_path)
+
+        self.assertIsNone(result_path)
+        self.assertFalse(os.path.exists(output_fasta_path))
+
+
+class ReadPlasmidScoresTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
+
+    def test_splits_context_and_contig_rows(self):
+        summary_path = os.path.join(self.tmp_dir, 'plasmid_summary.tsv')
+        summary_df = pd.DataFrame({
+            'seq_name': ['geneA|in_ctx1|out_ctx1', 'contig2'],
+            'length': [1234, 5678],
+            'plasmid_score': [0.9, 0.1],
+        })
+        summary_df.to_csv(summary_path, sep='\t', index=False)
+
+        context_plasmid_scores, contig_plasmid_scores = pdu.read_plasmid_scores(summary_path)
+
+        self.assertListEqual(list(context_plasmid_scores.columns), ['gene', 'in_context', 'out_context', 'plasmid_score'])
+        self.assertEqual(len(context_plasmid_scores), 1)
+        row = context_plasmid_scores.iloc[0]
+        self.assertEqual(row['gene'], 'geneA')
+        self.assertEqual(row['in_context'], 'in_ctx1')
+        self.assertEqual(row['out_context'], 'out_ctx1')
+        self.assertEqual(row['plasmid_score'], 0.9)
+
+        self.assertListEqual(list(contig_plasmid_scores.columns), ['contig', 'plasmid_score'])
+        self.assertEqual(len(contig_plasmid_scores), 1)
+        row = contig_plasmid_scores.iloc[0]
+        self.assertEqual(row['contig'], 'contig2')
+        self.assertEqual(row['plasmid_score'], 0.1)
+
+
+class AddPlasmidScoresToCsvTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
+
+    def test_add_plasmid_scores_to_context_level_csv(self):
+        csv_path = os.path.join(self.tmp_dir, 'context_level_matches.csv')
+        pd.DataFrame({
+            'gene': ['geneA', 'geneB'],
+            'in_context': ['in_ctx1', 'in_ctx2'],
+            'out_context': ['out_ctx1', 'out_ctx2'],
+            'score': [0.9, 0.8],
+        }).to_csv(csv_path, index=False)
+
+        context_plasmid_scores = pd.DataFrame({
+            'gene': ['geneA'],
+            'in_context': ['in_ctx1'],
+            'out_context': ['out_ctx1'],
+            'plasmid_score': [0.7],
+        })
+
+        pdu.add_plasmid_scores_to_context_level_csv(csv_path, context_plasmid_scores)
+
+        result = pd.read_csv(csv_path)
+        self.assertEqual(result.loc[result['gene'] == 'geneA', 'plasmid_score'].iloc[0], 0.7)
+        # genes with no plasmid score reported by GeNomad default to 0
+        self.assertEqual(result.loc[result['gene'] == 'geneB', 'plasmid_score'].iloc[0], 0.0)
+
+    def test_add_plasmid_scores_to_genes_no_species_match_csv(self):
+        csv_path = os.path.join(self.tmp_dir, 'genes_detected_in_graph_with_no_species_match.csv')
+        pd.DataFrame({
+            'gene': ['geneA', 'geneB'],
+            'contig': ['contig1', 'contig2'],
+            'gene_match_score': [1.0, 0.95],
+        }).to_csv(csv_path, index=False)
+
+        contig_plasmid_scores = pd.DataFrame({
+            'contig': ['contig1'],
+            'plasmid_score': [0.4],
+        })
+
+        pdu.add_plasmid_scores_to_genes_no_species_match_csv(csv_path, contig_plasmid_scores)
+
+        result = pd.read_csv(csv_path)
+        self.assertEqual(result.loc[result['gene'] == 'geneA', 'plasmid_score'].iloc[0], 0.4)
+        self.assertEqual(result.loc[result['gene'] == 'geneB', 'plasmid_score'].iloc[0], 0.0)
+
+
+class RunGenomadTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
+
+    class Dummy:
+        def __init__(self, stdout='', stderr='', returncode=0):
+            self.stdout = stdout
+            self.stderr = stderr
+            self.returncode = returncode
+
+    def test_raises_if_genomad_db_missing(self):
+        fasta_path = os.path.join(self.tmp_dir, 'plasmid_input.fasta')
+        with open(fasta_path, 'w') as f:
+            f.write('>seq1\nACGT\n')
+
+        with self.assertRaises(Exception):
+            pdu.run_genomad(fasta_path, os.path.join(self.tmp_dir, 'out'),
+                            os.path.join(self.tmp_dir, 'missing_genomad_db'), threads=1)
+
+    def test_runs_genomad_and_returns_summary_path(self):
+        fasta_path = os.path.join(self.tmp_dir, 'plasmid_input.fasta')
+        with open(fasta_path, 'w') as f:
+            f.write('>seq1\nACGT\n')
+        genomad_db = os.path.join(self.tmp_dir, 'genomad_db')
+        os.makedirs(genomad_db)
+        output_dir = os.path.join(self.tmp_dir, 'genomad_output')
+
+        with patch('ginger.plasmid_detection_utils.run', return_value=self.Dummy()) as mock_run:
+            summary_path = pdu.run_genomad(fasta_path, output_dir, genomad_db, threads=4)
+
+        self.assertEqual(summary_path,
+                        os.path.join(output_dir, 'plasmid_input_summary', 'plasmid_input_plasmid_summary.tsv'))
+        command = mock_run.call_args[0][0]
+        self.assertIn('genomad end-to-end', command)
+        self.assertIn('--threads 4', command)
+        self.assertIn(fasta_path, command)
+        self.assertIn(output_dir, command)
+        self.assertIn(genomad_db, command)
+
+    def test_raises_if_genomad_fails(self):
+        fasta_path = os.path.join(self.tmp_dir, 'plasmid_input.fasta')
+        with open(fasta_path, 'w') as f:
+            f.write('>seq1\nACGT\n')
+        genomad_db = os.path.join(self.tmp_dir, 'genomad_db')
+        os.makedirs(genomad_db)
+        output_dir = os.path.join(self.tmp_dir, 'genomad_output')
+
+        with patch('ginger.plasmid_detection_utils.run', return_value=self.Dummy(stderr='boom', returncode=1)):
+            with self.assertRaises(Exception):
+                pdu.run_genomad(fasta_path, output_dir, genomad_db, threads=1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Run GeNomad on each gene's in+gene+out context sequence (and on the contigs of genes with no species-level match) to estimate plasmid likelihood, controlled by --add-plasmid-score/--no-add-plasmid-score (default on) and --genomad-db.

Adds plasmid_score to context_level_matches.csv and genes_detected_in_graph_with_no_species_match.csv, and plasmid_score_mean / plasmid_score_most_common_context to species_level_matches.csv. Adds a new ginger/plasmid_detection_utils.py module, a 'plasmid' --keep-intermediate category, README docs, and tests.