### PR TITLE
Filter Kraken species by distinct-kmer-to-genome-length ratio

### DIFF
--- a/ginger/reference_database_utils.py
+++ b/ginger/reference_database_utils.py
@@ -22,7 +22,7 @@ URLOPEN_TIMEOUT = 60
 N_ATTEMPTS = 10
 SLEEP_SECS = 60
 BRACKEN_MIN_READS_RELAXATION_FACTOR = 0.5
-DISTINCT_KMER_COUNT_THRESHOLD = 200000
+DISTINCT_KMER_RATIO_THRESHOLD = 0.05
 KRAKEN_REPORT_COLS = ['pct', 'reads_clade', 'reads_direct', 'kmer_count', 'distinct_kmer_count', 'rank', 'taxid', 'name']
 
 
@@ -70,14 +70,24 @@ def run_kraken(reads_1, reads_2, threads, output_path, report_path, kraken_db):
 
 
 def filter_kraken_report_by_distinct_kmer_count(kraken_report_path, filtered_kraken_report_path,
-                                               threshold=DISTINCT_KMER_COUNT_THRESHOLD):
-    """Drop low-confidence species rows (low distinct_kmer_count) from a Kraken2 report.
+                                               metadata_path, max_refs_per_species,
+                                               threshold=DISTINCT_KMER_RATIO_THRESHOLD):
+    """Drop low-confidence species rows (low distinct_kmer_count / genome_length ratio) from a Kraken2 report.
 
-    Non-species rows are kept untouched, since Bracken needs them for its tree walk.
+    Species with no estimable genome length (e.g. missing from the reference metadata) are dropped,
+    since the ratio can't be computed. Non-species rows are kept untouched, since Bracken needs them
+    for its tree walk.
     """
     report = pd.read_csv(kraken_report_path, sep='\t', header=None, names=KRAKEN_REPORT_COLS)
     species_mask = report['rank'] == 'S'
-    keep_species_mask = species_mask & (report['distinct_kmer_count'] > threshold)
+    species_names = report.loc[species_mask, 'name'].str.strip().tolist()
+
+    metadata = pd.read_csv(metadata_path, sep='\t')
+    genome_length_by_species = get_species_median_genome_length_by_quality(metadata, species_names, max_refs_per_species)
+
+    genome_lengths = report['name'].str.strip().map(genome_length_by_species)
+    kmer_ratio = report['distinct_kmer_count'] / genome_lengths
+    keep_species_mask = species_mask & (kmer_ratio > threshold)
     filtered_report = report[~species_mask | keep_species_mask]
     filtered_report.to_csv(filtered_kraken_report_path, sep='\t', header=False, index=False, float_format='%.2f')
 
@@ -325,7 +335,8 @@ def get_filtered_references_database(reads_1, reads_2, threads, kraken_output_pa
     pu.check_and_make_dir_no_file_name(references_folder)
     run_kraken(reads_1, reads_2, threads, kraken_output_path, kraken_report_path, kraken_db)
     filtered_kraken_report_path = f'{kraken_report_path}.distinct_kmer_filtered'
-    filter_kraken_report_by_distinct_kmer_count(kraken_report_path, filtered_kraken_report_path)
+    filter_kraken_report_by_distinct_kmer_count(kraken_report_path, filtered_kraken_report_path,
+                                                metadata_path, max_species_representatives)
 
     avg1, max1, avg2, max2 = get_paired_reads_seqkit_stats(reads_1, reads_2)
     avg_sum = avg1 + avg2

--- a/tests/test_files/kraken_report_filter_test_metadata.tsv
+++ b/tests/test_files/kraken_report_filter_test_metadata.tsv
@@ -1,0 +1,3 @@
+Genome	Completeness	Contamination	N50	FTP_download	species	Length
+SP_1	99.0	0.0	100000	ftp://example/SP_1.gff.gz	SpeciesPass	3000000
+SF_1	99.0	0.0	100000	ftp://example/SF_1.gff.gz	SpeciesFail	5000000

--- a/tests/test_reference_database_utils.py
+++ b/tests/test_reference_database_utils.py
@@ -90,10 +90,14 @@ class MyTestCase(unittest.TestCase):
 
     def test_filter_kraken_report_by_distinct_kmer_count(self):
         kraken_report_path = f'{TEST_FILES}/kraken_report_filter_test.txt'
+        metadata_path = f'{TEST_FILES}/kraken_report_filter_test_metadata.tsv'
         with tempfile.TemporaryDirectory() as tmpdir:
             filtered_path = os.path.join(tmpdir, 'filtered_report.txt')
-            rdu.filter_kraken_report_by_distinct_kmer_count(kraken_report_path, filtered_path, threshold=200000)
+            rdu.filter_kraken_report_by_distinct_kmer_count(kraken_report_path, filtered_path,
+                                                             metadata_path, max_refs_per_species=1)
             filtered = pd.read_csv(filtered_path, sep='\t', header=None, names=rdu.KRAKEN_REPORT_COLS)
+
+        # SpeciesPass: 300000 / 3000000 = 0.1 (pass); SpeciesFail: 50000 / 5000000 = 0.01 (fail)
 
         # non-species rows (U, R, G) are kept regardless of distinct_kmer_count
         self.assertEqual(set(filtered.loc[filtered['rank'] != 'S', 'taxid']), {0, 1, 100})


### PR DESCRIPTION
Replace the absolute distinct_kmer_count threshold with a ratio (distinct_kmer_count / estimated genome length > 0.05), reusing get_species_median_genome_length_by_quality so the filter scales with genome size instead of penalizing large genomes.